### PR TITLE
Add AI service

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,0 +1,1 @@
+OPEN_AI_KEY=

--- a/Gemfile
+++ b/Gemfile
@@ -39,6 +39,10 @@ gem 'bootsnap', '>= 1.16.0', require: false
 gem 'devise'
 gem "omniauth"
 gem "omniauth-linkedin-oauth2"
+# HTTP client library abstraction layer: https://github.com/lostisland/faraday
+gem 'faraday'
+# Library for building HTTP user-agents: https://github.com/ruby/net-http
+gem 'net-http'
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile
+++ b/Gemfile
@@ -50,6 +50,8 @@ group :development, :test do
   gem 'pry'
   gem 'rspec-rails'
   gem 'shoulda-matchers'
+  # Library for stubbing HTTP requests
+  gem 'webmock'
 end
 
 group :development do

--- a/Gemfile
+++ b/Gemfile
@@ -21,7 +21,7 @@ gem 'uglifier', '>= 1.3.0'
 # Use CoffeeScript for .coffee assets and views
 gem 'coffee-rails', '~> 4.2'
 # Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder
-gem 'jbuilder', '~> 2.5'
+# gem 'jbuilder', '~> 2.5'
 # Use Redis adapter to run Action Cable in production
 # gem 'redis', '~> 4.0'
 # Use ActiveModel has_secure_password
@@ -54,6 +54,5 @@ group :development do
   gem 'listen', '>= 3.0.5', '< 3.2'
 end
 
-
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
-gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
+# gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -42,6 +42,8 @@ GEM
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
+    addressable (2.8.1)
+      public_suffix (>= 2.0.2, < 6.0)
     arel (9.0.0)
     bcrypt (3.1.18)
     bindex (0.8.1)
@@ -57,6 +59,8 @@ GEM
       execjs
     coffee-script-source (1.12.2)
     concurrent-ruby (1.2.0)
+    crack (0.4.5)
+      rexml
     crass (1.0.6)
     date (3.3.3)
     devise (4.8.1)
@@ -77,6 +81,7 @@ GEM
       sass (>= 3.2)
     globalid (1.1.0)
       activesupport (>= 5.0)
+    hashdiff (1.0.1)
     hashie (5.0.0)
     i18n (1.12.0)
       concurrent-ruby (~> 1.0)
@@ -136,6 +141,7 @@ GEM
     pry (0.14.2)
       coderay (~> 1.1)
       method_source (~> 1.0)
+    public_suffix (5.0.1)
     puma (3.12.6)
     racc (1.6.2)
     rack (2.2.6.2)
@@ -174,6 +180,7 @@ GEM
     responders (3.1.0)
       actionpack (>= 5.2)
       railties (>= 5.2)
+    rexml (3.2.5)
     rspec-core (3.12.1)
       rspec-support (~> 3.12.0)
     rspec-expectations (3.12.2)
@@ -233,6 +240,10 @@ GEM
       activemodel (>= 5.0)
       bindex (>= 0.4.0)
       railties (>= 5.0)
+    webmock (3.18.1)
+      addressable (>= 2.8.0)
+      crack (>= 0.3.2)
+      hashdiff (>= 0.4.0, < 2.0.0)
     websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
@@ -259,6 +270,7 @@ DEPENDENCIES
   shoulda-matchers
   uglifier (>= 1.3.0)
   web-console (>= 3.3.0)
+  webmock
 
 RUBY VERSION
    ruby 2.7.4p191

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -100,6 +100,8 @@ GEM
     minitest (5.17.0)
     msgpack (1.6.0)
     multi_xml (0.6.0)
+    net-http (0.3.2)
+      uri
     net-imap (0.3.4)
       date
       net-protocol
@@ -222,6 +224,7 @@ GEM
       thread_safe (~> 0.1)
     uglifier (4.2.0)
       execjs (>= 0.3.0, < 3)
+    uri (0.12.0)
     version_gem (1.1.1)
     warden (1.2.9)
       rack (>= 2.0.9)
@@ -241,8 +244,10 @@ DEPENDENCIES
   bootsnap (>= 1.16.0)
   coffee-rails (~> 4.2)
   devise
+  faraday
   font-awesome-sass (~> 4.6.1)
   listen (>= 3.0.5, < 3.2)
+  net-http
   omniauth
   omniauth-linkedin-oauth2
   pg (>= 0.18, < 2.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -80,9 +80,6 @@ GEM
     hashie (5.0.0)
     i18n (1.12.0)
       concurrent-ruby (~> 1.0)
-    jbuilder (2.11.5)
-      actionview (>= 5.0.0)
-      activesupport (>= 5.0.0)
     jwt (2.7.0)
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)
@@ -91,7 +88,7 @@ GEM
     loofah (2.19.1)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
-    mail (2.8.0.1)
+    mail (2.8.1)
       mini_mime (>= 0.1.1)
       net-imap
       net-pop
@@ -113,7 +110,7 @@ GEM
     net-smtp (0.3.3)
       net-protocol
     nio4r (2.5.8)
-    nokogiri (1.14.1)
+    nokogiri (1.14.2)
       mini_portile2 (~> 2.8.0)
       racc (~> 1.4)
     oauth2 (2.0.9)
@@ -123,14 +120,15 @@ GEM
       rack (>= 1.2, < 4)
       snaky_hash (~> 2.0)
       version_gem (~> 1.1)
-    omniauth (1.9.2)
+    omniauth (2.1.1)
       hashie (>= 3.4.6)
-      rack (>= 1.6.2, < 3)
+      rack (>= 2.2.3)
+      rack-protection
     omniauth-linkedin-oauth2 (1.0.0)
       omniauth-oauth2
-    omniauth-oauth2 (1.7.3)
+    omniauth-oauth2 (1.8.0)
       oauth2 (>= 1.4, < 3)
-      omniauth (>= 1.9, < 3)
+      omniauth (~> 2.0)
     orm_adapter (0.5.0)
     pg (1.4.5)
     pry (0.14.2)
@@ -139,6 +137,8 @@ GEM
     puma (3.12.6)
     racc (1.6.2)
     rack (2.2.6.2)
+    rack-protection (3.0.5)
+      rack
     rack-test (2.0.2)
       rack (>= 1.3)
     rails (5.2.8.1)
@@ -172,7 +172,7 @@ GEM
     responders (3.1.0)
       actionpack (>= 5.2)
       railties (>= 5.2)
-    rspec-core (3.12.0)
+    rspec-core (3.12.1)
       rspec-support (~> 3.12.0)
     rspec-expectations (3.12.2)
       diff-lcs (>= 1.2.0, < 2.0)
@@ -242,7 +242,6 @@ DEPENDENCIES
   coffee-rails (~> 4.2)
   devise
   font-awesome-sass (~> 4.6.1)
-  jbuilder (~> 2.5)
   listen (>= 3.0.5, < 3.2)
   omniauth
   omniauth-linkedin-oauth2
@@ -253,7 +252,6 @@ DEPENDENCIES
   rspec-rails
   sass-rails (~> 5.0)
   shoulda-matchers
-  tzinfo-data
   uglifier (>= 1.3.0)
   web-console (>= 3.3.0)
 

--- a/app/models/cover_letter.rb
+++ b/app/models/cover_letter.rb
@@ -1,0 +1,7 @@
+class CoverLetter
+  def initialize(content: "")
+    @content = content
+  end
+
+  attr_reader :content
+end

--- a/app/services/open_ai.rb
+++ b/app/services/open_ai.rb
@@ -1,0 +1,3 @@
+module OpenAI
+  URL_PREFIX = "https://api.openai.com/v1/".freeze
+end

--- a/app/services/open_ai.rb
+++ b/app/services/open_ai.rb
@@ -1,3 +1,4 @@
 module OpenAI
   URL_PREFIX = "https://api.openai.com/v1/".freeze
+  class APIError < StandardError; end
 end

--- a/app/services/open_ai/client.rb
+++ b/app/services/open_ai/client.rb
@@ -1,0 +1,30 @@
+module OpenAI
+  class Client
+    def initialize(url: URL_PREFIX)
+      @url = url
+    end
+
+    def post(action:, body:, headers: default_headers)
+      conn.post(action) do |req|
+        req.headers = headers
+        req.body = body.to_json
+      end
+    end
+
+    private
+
+    def conn
+      @conn ||= Faraday.new do |c|
+        c.adapter(Faraday.default_adapter)
+        c.url_prefix = URL_PREFIX
+      end
+    end
+
+    def default_headers
+      {
+        "Authorization": "Bearer #{ENV.fetch('OPEN_AI_KEY')}",
+        "Content-Type": "application/json"
+      }
+    end
+  end
+end

--- a/app/services/open_ai/text_service.rb
+++ b/app/services/open_ai/text_service.rb
@@ -1,0 +1,34 @@
+module OpenAI
+  class TextService
+    URL_PREFIX = "https://api.openai.com/v1/".freeze
+
+    def initialize(client: Client.new)
+      @client = client
+    end
+
+    def cover_letter(prompt)
+      request_body = defaults.merge({"prompt": prompt})
+      response = client.post(action: "completions", body: request_body)
+      response_body = JSON.parse(response.body)
+
+      raise APIError.new(response_body["error"]["message"]) if response.status != 200 && response_body["error"] != nil
+
+      CoverLetter.new(content: response_body["choices"][0]["text"])
+    end
+
+    private
+
+    attr_reader :client
+
+    def defaults
+      {
+        "model": "text-davinci-003",
+        "temperature": 0.6,
+        "top_p": 1.0,
+        "max_tokens": 256,
+        "frequency_penalty": 0.0,
+        "presence_penalty": 0.0
+      }
+    end
+  end
+end

--- a/spec/services/open_ai/client_spec.rb
+++ b/spec/services/open_ai/client_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe OpenAI::Client do
     after { WebMock.disallow_net_connect! }
 
     context "success" do
-      it "returns text" do
+      it "returns text", :unstubbed do
         body = {
           "model": "text-davinci-003",
           "temperature": 0.6,
@@ -30,7 +30,7 @@ RSpec.describe OpenAI::Client do
     end
 
     context "failure" do
-      it "errors for missing attributes" do
+      it "returns an error message", :unstubbed do
         body = {
           "temperature": 0.6,
           "top_p": 1.0,

--- a/spec/services/open_ai/client_spec.rb
+++ b/spec/services/open_ai/client_spec.rb
@@ -1,0 +1,50 @@
+
+require "rails_helper"
+
+RSpec.describe OpenAI::Client do
+  describe "post" do
+    subject(:client) { OpenAI::Client.new() }
+    before { WebMock.allow_net_connect! }
+    after { WebMock.disallow_net_connect! }
+
+    context "success" do
+      it "returns text" do
+        body = {
+          "model": "text-davinci-003",
+          "temperature": 0.6,
+          "top_p": 1.0,
+          "max_tokens": 256,
+          "frequency_penalty": 0.0,
+          "presence_penalty": 0.0,
+          "prompt": "Write a cover letter for a software engineer role at Open AI"
+        }
+
+        res = client.post(action: "completions", body: body)
+
+        expect(res.body["error"]).to be(nil)
+        expect(res.status).to eq(200)
+
+        content = JSON.parse(res.body)["choices"][0]["text"]
+        expect(content.blank?).to be(false)
+      end
+    end
+
+    context "failure" do
+      it "errors for missing attributes" do
+        body = {
+          "temperature": 0.6,
+          "top_p": 1.0,
+          "max_tokens": 256,
+          "frequency_penalty": 0.0,
+          "presence_penalty": 0.0,
+          "prompt": "Write a cover letter for a software engineer role at Open AI"
+        }
+
+        res = client.post(action: "completions", body: body)
+
+        expect(res.body["error"]).to_not be(nil)
+        expect(res.status).to eq(400)
+      end
+    end
+  end
+end

--- a/spec/services/open_ai/text_service_spec.rb
+++ b/spec/services/open_ai/text_service_spec.rb
@@ -1,0 +1,23 @@
+
+require "rails_helper"
+
+RSpec.describe OpenAI::TextService do
+  describe "cover_letter" do
+    subject(:service) { OpenAI::TextService.new() }
+
+    context "success" do
+      it "returns a cover letter" do
+        cover_letter = service.cover_letter("Write a cover letter for a software engineer role at Open AI")
+
+        expect(cover_letter.content.present?).to be(true)
+      end
+    end
+    context "failure", :stub_ai_failure do
+      it "raises an error" do
+        expect do
+          service.cover_letter("Write a cover letter")
+        end.to raise_error(OpenAI::APIError, "A wild error appeared!")
+      end
+    end
+  end
+end

--- a/spec/support/stubber.rb
+++ b/spec/support/stubber.rb
@@ -1,0 +1,36 @@
+require 'json'
+
+module Stubber
+  def stub_open_ai_completions_text(success: true)
+    if success
+      JSON.generate({
+        "id": "5tu6-0p3nA1-t3xt-dav1nc1-003",
+        "object": "text_completion",
+        "created": 1676187649,
+        "model": "text-davinci-003",
+        "choices": [
+            {
+              "text": "\n\nDear Open AI Hiring Team,\n\nI am writing to apply for the Software Engineer role at Open AI. With a degree in Computer Science and five years of experience in software engineering, I am confident that I am the ideal candidate for the job.\n\nAs a software engineer, I have worked on a number of projects for a variety of clients. I have experience developing web applications, mobile apps, and other software solutions. My experience also includes working with databases, designing user interfaces, and debugging code. I am highly skilled in a range of programming languages, including C++, Java, and Python.\n\nI am passionate about artificial intelligence and am excited to join a company like Open AI, which is at the forefront of this technology. I am confident that my skills, experience, and enthusiasm would make me a valuable asset to your team.\n\nI am excited to learn more about the position and discuss how I can contribute to Open AI’s success. Thank you for your time and consideration.\n\nSincerely,\n\n[Your Name]",
+              "index": 0,
+              "logprobs": nil,
+              "finish_reason": "stop"
+            }
+        ],
+        "usage": {
+          "prompt_tokens": 12,
+          "completion_tokens": 218,
+          "total_tokens": 230
+        }
+      })
+    else
+      JSON.generate({
+        "error": {
+          "message": "A wild error appeared!",
+          "type": "invalid_request_error",
+          "param": nil,
+          "code": nil
+        }
+      })
+    end
+  end
+end


### PR DESCRIPTION
#4 

### Problem
We'd like to leverage artificial intelligence to streamline creating cover letters. We need a way to access AI to generate content for cover letters.

### Solution
This PR uses an artificial intelligence driven API by a third party, OpenAI, to generate cover letter content. It creates a general client to connect to OpenAI's API, a tailored service to receive this client and handle our internal business logic, and stubs to reduce expenses and test duration. 

The service especially will probably change as we build on to it. Locally, tests should pass after this env var has been added to the gitignored .env file. Tests default to use stubs unless they have `:unstubbed` tags.

### Deployment
Adds a required env var:`OPEN_AI_KEY`