### PR TITLE
Add .env to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,5 @@
 
 # Ignore master key for decrypting credentials and more.
 /config/master.key
+
+.env


### PR DESCRIPTION
### Problem
We don't want to publish environment variables that are added to  `.env`.

### Solution
Gitignore it. This will allow us to create a `.env` file in the root directly of our project locally, and add environment variables there (like the ones in `.env.sample`) without publishing them on GitHub for the world to see.