### PR TITLE
Add profile forms

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -39,6 +39,7 @@ gem 'bootsnap', '>= 1.16.0', require: false
 gem 'devise'
 gem "omniauth"
 gem "omniauth-linkedin-oauth2"
+gem "omniauth-rails_csrf_protection"
 # HTTP client library abstraction layer: https://github.com/lostisland/faraday
 gem 'faraday'
 # Library for building HTTP user-agents: https://github.com/ruby/net-http

--- a/Gemfile
+++ b/Gemfile
@@ -60,5 +60,13 @@ group :development do
   gem 'listen', '>= 3.0.5', '< 3.2'
 end
 
+group :test do
+  # Database cleaning around tests
+  gem 'database_cleaner'
+  # Integration test tools
+  gem 'capybara'
+  gem 'selenium-webdriver'
+end
+
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 # gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -50,6 +50,15 @@ GEM
     bootsnap (1.16.0)
       msgpack (~> 1.2)
     builder (3.2.4)
+    capybara (3.38.0)
+      addressable
+      matrix
+      mini_mime (>= 0.1.3)
+      nokogiri (~> 1.8)
+      rack (>= 1.6.0)
+      rack-test (>= 0.6.3)
+      regexp_parser (>= 1.5, < 3.0)
+      xpath (~> 3.2)
     coderay (1.1.3)
     coffee-rails (4.2.2)
       coffee-script (>= 2.2.0)
@@ -62,6 +71,12 @@ GEM
     crack (0.4.5)
       rexml
     crass (1.0.6)
+    database_cleaner (2.0.1)
+      database_cleaner-active_record (~> 2.0.0)
+    database_cleaner-active_record (2.0.1)
+      activerecord (>= 5.a)
+      database_cleaner-core (~> 2.0.0)
+    database_cleaner-core (2.0.1)
     date (3.3.3)
     devise (4.8.1)
       bcrypt (~> 3.0)
@@ -99,6 +114,7 @@ GEM
       net-pop
       net-smtp
     marcel (1.0.2)
+    matrix (0.4.2)
     method_source (1.0.0)
     mini_mime (1.1.2)
     mini_portile2 (2.8.1)
@@ -177,6 +193,7 @@ GEM
     rb-fsevent (0.11.2)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
+    regexp_parser (2.7.0)
     responders (3.1.0)
       actionpack (>= 5.2)
       railties (>= 5.2)
@@ -200,6 +217,7 @@ GEM
     rspec-support (3.12.0)
     ruby2_keywords (0.0.5)
     ruby_dep (1.5.0)
+    rubyzip (2.3.2)
     sass (3.7.4)
       sass-listen (~> 4.0.0)
     sass-listen (4.0.0)
@@ -211,6 +229,10 @@ GEM
       sprockets (>= 2.8, < 4.0)
       sprockets-rails (>= 2.0, < 4.0)
       tilt (>= 1.1, < 3)
+    selenium-webdriver (4.8.0)
+      rexml (~> 3.2, >= 3.2.5)
+      rubyzip (>= 1.2.2, < 3.0)
+      websocket (~> 1.0)
     shoulda-matchers (5.3.0)
       activesupport (>= 5.2.0)
     snaky_hash (2.0.1)
@@ -244,16 +266,21 @@ GEM
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
+    websocket (1.2.9)
     websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
+    xpath (3.2.0)
+      nokogiri (~> 1.8)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
   bootsnap (>= 1.16.0)
+  capybara
   coffee-rails (~> 4.2)
+  database_cleaner
   devise
   faraday
   font-awesome-sass (~> 4.6.1)
@@ -267,6 +294,7 @@ DEPENDENCIES
   rails (~> 5.2.8, >= 5.2.8.1)
   rspec-rails
   sass-rails (~> 5.0)
+  selenium-webdriver
   shoulda-matchers
   uglifier (>= 1.3.0)
   web-console (>= 3.3.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -152,6 +152,9 @@ GEM
     omniauth-oauth2 (1.8.0)
       oauth2 (>= 1.4, < 3)
       omniauth (~> 2.0)
+    omniauth-rails_csrf_protection (1.0.1)
+      actionpack (>= 4.2)
+      omniauth (~> 2.0)
     orm_adapter (0.5.0)
     pg (1.4.5)
     pry (0.14.2)
@@ -288,6 +291,7 @@ DEPENDENCIES
   net-http
   omniauth
   omniauth-linkedin-oauth2
+  omniauth-rails_csrf_protection
   pg (>= 0.18, < 2.0)
   pry
   puma (~> 3.11)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,3 +1,7 @@
 class ApplicationController < ActionController::Base
-  before_action :authenticate_user!
+  before_action :authenticate_user!, :require_profile
+
+  def require_profile
+    redirect_to new_profile_path if current_user && current_user.profile.nil?
+  end
 end

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -1,10 +1,4 @@
 class HomeController < ApplicationController
-  before_action :require_profile
-
   def index
-  end
-
-  def require_profile
-    redirect_to new_profile_path unless current_user && current_user.profile
   end
 end

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -12,6 +12,17 @@ class ProfilesController < ApplicationController
     redirect_to home_index_path
   end
 
+  def edit
+    @profile = Profile.find_by(user_id: current_user.id)
+  end
+
+  def update
+    profile = Profile.find_by(user_id: current_user.id)
+    profile.update(profile_params)
+
+    redirect_to home_index_path
+  end
+
   private
 
   def profile_params

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -1,3 +1,20 @@
 class ProfilesController < ApplicationController
-  def new; end
+  skip_before_action :require_profile, only: [:new, :create]
+
+  def new
+    @profile = Profile.new()
+  end
+
+  def create
+    attributes = profile_params.merge({user_id: current_user.id})
+    Profile.create(attributes)
+
+    redirect_to home_index_path
+  end
+
+  private
+
+  def profile_params
+    params.require(:profile).permit(:skills, :experience, :education, :projects)
+  end
 end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,0 +1,3 @@
+class SessionsController < Devise::OmniauthCallbacksController
+  skip_before_action :require_profile
+end

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -4,6 +4,7 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
 
     if @user.persisted?
       sign_in @user, event: :authentication
+
       if @user.profile
         redirect_to home_path
       else

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -1,0 +1,3 @@
+class Users::SessionsController < Devise::SessionsController
+  skip_before_action :require_profile
+end

--- a/app/views/profiles/_form.html.erb
+++ b/app/views/profiles/_form.html.erb
@@ -1,4 +1,4 @@
-<%= form_with model: @profile do |f| %>
+<%= form_for @profile, url: profile_path do |f| %>
   <%= render "paragraph_input", {f: f, attribute: :skills, placeholder: ""} %>
   <%= render "paragraph_input", {f: f, attribute: :experience, placeholder: ""} %>
   <%= render "paragraph_input", {f: f, attribute: :education, placeholder: "" } %>

--- a/app/views/profiles/_form.html.erb
+++ b/app/views/profiles/_form.html.erb
@@ -1,0 +1,7 @@
+<%= form_with model: @profile do |f| %>
+  <%= render "paragraph_input", {f: f, attribute: :skills, placeholder: ""} %>
+  <%= render "paragraph_input", {f: f, attribute: :experience, placeholder: ""} %>
+  <%= render "paragraph_input", {f: f, attribute: :education, placeholder: "" } %>
+  <%= render "paragraph_input", {f: f, attribute: :projects, placeholder: "" } %>
+  <%= f.submit "Submit" %>
+<% end %>

--- a/app/views/profiles/_paragraph_input.html.erb
+++ b/app/views/profiles/_paragraph_input.html.erb
@@ -1,0 +1,4 @@
+  <div>
+    <%= f.label attribute, placeholder: placeholder %>
+    <%= f.text_area attribute, placeholder: placeholder %>
+  </div>

--- a/app/views/profiles/edit.html.erb
+++ b/app/views/profiles/edit.html.erb
@@ -1,0 +1,2 @@
+<h1>Edit Profile</h1>
+<%= render "form" %>

--- a/app/views/profiles/new.html.erb
+++ b/app/views/profiles/new.html.erb
@@ -1,1 +1,2 @@
 <h1>New Profile</h1>
+<%= render "form" %>

--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -16,6 +16,11 @@
       <a href="/about/">About</a>
     </li>
     <% if user_signed_in? %>
+      <% if current_user.profile.present? %>
+        <li>
+          <%= link_to "Edit Profile", edit_profile_path, method: :get %>
+        </li>
+      <% end %>
       <li>
         <%= link_to "Log Out", destroy_user_session_path, method: :delete %>
       </li>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,8 +1,8 @@
 Rails.application.routes.draw do
-  devise_for :users, controllers: { omniauth_callbacks: 'users/omniauth_callbacks' }
+  devise_for :users, controllers: { omniauth_callbacks: 'users/omniauth_callbacks', sessions: 'users/sessions' }
   get 'home/index'
   devise_for :views
   root to: "home#index"
 
-  resources :profiles, only: [:new, :create]
+  resource :profile, only: [:new, :create, :update, :edit]
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,5 +4,5 @@ Rails.application.routes.draw do
   devise_for :views
   root to: "home#index"
 
-  resources :profiles, only: [:new]
+  resources :profiles, only: [:new, :create]
 end

--- a/spec/feature_helper.rb
+++ b/spec/feature_helper.rb
@@ -1,0 +1,19 @@
+require 'rails_helper'
+require 'capybara/rspec'
+
+RSpec.configure do |config|
+  # Include Warden, to enable access to faster sign in options for integration tests (#login_as)
+  config.include Warden::Test::Helpers
+
+  # Enabling headless will run feature specs in the background
+  # Otherwise, feature specs will default to opening a window.
+  headless_mode = ENV.fetch("HEADLESS", "false").downcase
+  puts "HEADLESS MODE #{headless_mode}"
+
+  case ENV.fetch("HEADLESS", "false").downcase
+  when "true", "1"
+    Capybara.default_driver = :selenium_chrome_headless
+  else
+    Capybara.default_driver = :selenium_chrome
+  end
+end

--- a/spec/features/onboarding_spec.rb
+++ b/spec/features/onboarding_spec.rb
@@ -28,6 +28,8 @@ RSpec.describe "Onboarding", type: :feature do
       click_on "Sign up"
 
       expect(page).to have_current_path(new_profile_path)
+      expect(page).to have_content("New Profile")
+      expect(page).to_not have_link(edit_profile_path) # Nav link that displays after profile creation
 
       fill_in "Skills", with: input.skills
       fill_in "Experience", with: input.experience
@@ -57,6 +59,29 @@ RSpec.describe "Onboarding", type: :feature do
 
       expect(page).to have_content("Home")
     end
+
+    it "can sign out without completing onboarding" do
+      visit root_path
+
+      expect(page).to have_current_path(new_user_session_path)
+
+      click_on "Sign up"
+
+      expect(page).to have_current_path(new_user_registration_path)
+
+      fill_in "Email", with: input.email
+      fill_in "Password", with: input.password
+      fill_in "Password confirmation", with: input.password
+      click_on "Sign up"
+
+      expect(page).to have_current_path(new_profile_path)
+      expect(page).to have_content("New Profile")
+      expect(page).to_not have_link(edit_profile_path) # Nav link that displays after profile creation
+
+      click_on "Log Out"
+
+      expect(page).to have_content("Log in")
+    end
   end
 
   context "returning new user" do
@@ -69,9 +94,11 @@ RSpec.describe "Onboarding", type: :feature do
         Profile.create(user_id: user.id, skills: input.skills, experience: input.experience, education: input.education, projects: input.projects)
       end
 
-      visit root_path
+      visit home_index_path
 
+      expect(page).to have_current_path(home_index_path)
       expect(page).to have_content("Home")
+      expect(page).to have_content("Edit Profile")
     end
 
     it "is directed to continue onboarding if profile is missing" do

--- a/spec/features/onboarding_spec.rb
+++ b/spec/features/onboarding_spec.rb
@@ -1,0 +1,83 @@
+require "feature_helper"
+
+RSpec.describe "Onboarding", type: :feature do
+  let(:input) do
+    OpenStruct.new(
+      email: "test@example.com",
+      password: "verysecurepassword123",
+      skills: "Exploring",
+      experience: "Digital Dreamweaver Computer Conjuror DevOps Dynamo Algorithm Alchemist",
+      education: "Artificial Intelligence",
+      projects: "CoverGetter"
+    )
+  end
+
+  context "new user" do
+    it "can complete onboarding flow and sign in" do
+      visit root_path
+
+      expect(page).to have_current_path(new_user_session_path)
+
+      click_on "Sign up"
+
+      expect(page).to have_current_path(new_user_registration_path)
+
+      fill_in "Email", with: input.email
+      fill_in "Password", with: input.password
+      fill_in "Password confirmation", with: input.password
+      click_on "Sign up"
+
+      expect(page).to have_current_path(new_profile_path)
+
+      fill_in "Skills", with: input.skills
+      fill_in "Experience", with: input.experience
+      fill_in "Education", with: input.education
+      fill_in "Projects", with: input.projects
+      click_on "Submit"
+
+      expect(page).to have_content("Home")
+
+      user = User.find_by(email: input.email)
+      profile = user.profile
+
+      expect(user.nil?).to be(false)
+      expect(profile.nil?).to be(false)
+      expect(profile.skills).to eq(input.skills)
+      expect(profile.experience).to eq(input.experience)
+      expect(profile.education).to eq(input.education)
+      expect(profile.projects).to eq(input.projects)
+
+      click_on "Log Out"
+
+      expect(page).to have_content("Log in")
+
+      fill_in "Email", with: input.email
+      fill_in "Password", with: input.password
+      click_on "Log in"
+
+      expect(page).to have_content("Home")
+    end
+  end
+
+  context "returning new user" do
+    let(:user) { User.create(email: input.email, password: input.password, password_confirmation: input.password) }
+
+    before { login_as(user) }
+
+    it "is shown the home page if they've already made a profile" do
+      user.tap do |u|
+        Profile.create(user_id: user.id, skills: input.skills, experience: input.experience, education: input.education, projects: input.projects)
+      end
+
+      visit root_path
+
+      expect(page).to have_content("Home")
+    end
+
+    it "is directed to continue onboarding if profile is missing" do
+      visit root_path
+
+      expect(page).to have_current_path(new_profile_path)
+    end
+  end
+end

--- a/spec/features/profile_editing_spec.rb
+++ b/spec/features/profile_editing_spec.rb
@@ -1,0 +1,39 @@
+require "feature_helper"
+
+RSpec.describe "Profile editing", type: :feature do
+  let(:user) { User.create(email: "test@example.com", password: "verysecurepassword123", password_confirmation: "verysecurepassword123") }
+
+  before { login_as(user) }
+
+  context "signed in users" do
+    it "can edit their profile" do
+      previous = OpenStruct.new(
+        skills: "Exploring",
+        experience: "Digital Dreamweaver Computer Conjuror DevOps Dynamo Algorithm Alchemist",
+        education: "Artificial Intelligence",
+        projects: "CoverGetter"
+      )
+      Profile.create(user_id: user.id, skills: previous.skills, experience: previous.experience, education: previous.education, projects: previous.projects)
+
+      visit home_index_path
+      click_on "Edit Profile"
+
+      expect(page).to have_current_path(edit_profile_path())
+
+      updated = "Code Composer Program Poet Software Samurai"
+      fill_in "Experience", with: updated, fill_options: { clear: :backspace }
+      click_on "Submit"
+
+      expect(page).to have_content("Home")
+
+      profile = user.profile.reload
+
+      expect(user.nil?).to be(false)
+      expect(profile.nil?).to be(false)
+      expect(profile.experience).to eq(updated)
+      expect(profile.skills).to eq(previous.skills)
+      expect(profile.education).to eq(previous.education)
+      expect(profile.projects).to eq(previous.projects)
+    end
+  end
+end

--- a/spec/services/open_ai/client_spec.rb
+++ b/spec/services/open_ai/client_spec.rb
@@ -4,8 +4,6 @@ require "rails_helper"
 RSpec.describe OpenAI::Client do
   describe "post" do
     subject(:client) { OpenAI::Client.new() }
-    before { WebMock.allow_net_connect! }
-    after { WebMock.disallow_net_connect! }
 
     context "success" do
       it "returns text", :unstubbed do


### PR DESCRIPTION
#5

### Problem
We need a way for users to provide their skills, experience, and other details, so that our AI model can personalize a cover letter for them. 

### Solution
This PR adds an onboarding flow. Users can now create a profile that includes their skills, education, experience, and projects, and later edit these items. It also mixes in more setup and auth followup.

It's not stylish yet -- I'll look at that next in a separate PR.