### PR TITLE
Adjust the edit cover letter page and allow more tokens to be used 

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -34,5 +34,8 @@
 }
 
 .cover-letter {
+  padding: 1rem;
+  font-size: 14px;
+  text-align: left; 
   white-space: pre-wrap;
 }

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -6,7 +6,7 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
       sign_in @user, event: :authentication
 
       if @user.profile
-        redirect_to home_path
+        redirect_to home_index_path
       else
         redirect_to new_profile_path
       end

--- a/app/services/open_ai/text_service.rb
+++ b/app/services/open_ai/text_service.rb
@@ -25,7 +25,7 @@ module OpenAI
         "model": "text-davinci-003",
         "temperature": 0.6,
         "top_p": 1.0,
-        "max_tokens": 256,
+        "max_tokens": 700,
         "frequency_penalty": 0.0,
         "presence_penalty": 0.0
       }

--- a/app/services/prompt_builder.rb
+++ b/app/services/prompt_builder.rb
@@ -7,7 +7,7 @@ class PromptBuilder
   end
 
   def text
-    "Write me a cover letter. \n" +
+    "Write me a cover letter in 500 words or fewer. \n" +
       "The company is #{@job.company}. \n" +
       "The job title is #{@job.role}. \n" +
       description + 

--- a/app/views/jobs/edit.html.erb
+++ b/app/views/jobs/edit.html.erb
@@ -6,7 +6,6 @@
 <% end %>
 
 <%= form_for @job do |f| %>
-  <%= f.label :letter_text, "Cover letter" %>
-  <%= f.text_area :letter_text, placeholder: @job.letter_text %>
+  <%= render "shared/paragraph_input", {f: f, attribute: :letter_text, placeholder: @job.letter_text} %>
   <%= f.submit "Save" %>
 <% end %>


### PR DESCRIPTION
Problem: There were some issues with the way cover letters were being displayed. 
1. We did not have enough tokens to get a full cover letter
2. The edit cover letter page was not using the standard paragraph field for display, so the text area box was only big enough to see one line at a time
3. The cover letter on the show page was center-aligned, which was awkward for a letter. Also the text was pretty big which made it difficult to see the entire letter on a single page in a browser. 

Solutions (respectively:

1. Changed the max allowable tokens from 256 to 700. Added 'In 500 words or less' to the prompt to keep the responses brief, so they won't get cut off.
2. Changed the edit cover letter form to use the shared paragraph field partial for consistent formatting
3. Adjusted the CSS for the "cover-letter" class to (hopefully) improve the display

How this PR makes me feel: <img src="https://media1.giphy.com/media/syVeLgziu57Qk/giphy.gif"/>


